### PR TITLE
Add support for build targets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
   access_secret:
     description: "access_secret"
     required: true
+  build1:
+    description: "build1"
+    required: true
+  build2:
+    description: "build2"
+    required: true
 runs:
   using: composite
   steps:
@@ -33,13 +39,16 @@ runs:
         launchpad = Launchpad.login("${{inputs.consumer_name}}", "${{inputs.access_token}}", "${{inputs.access_secret}}",service_root, version='devel')
         ubuntu = launchpad.distributions["ubuntu"]
         release = ubuntu.getSeries(name_or_version="bionic")
-        amd64 = release.getDistroArchSeries(archtag="amd64")
-        arm64 = release.getDistroArchSeries(archtag="arm64")
         edgex_team = launchpad.people["canonical-edgex"]
         snap = launchpad.snaps.getByName(name="${{inputs.edgex_snap}}", owner=edgex_team)
+
         # it's not obvious from the documentation - but we need to specify the channel used for snapcraft, otherwise we get an old version
-        request = snap.requestBuild(archive=ubuntu.main_archive, distro_arch_series=amd64, pocket='Updates', channels={"snapcraft":"edge"})
-        print(request)
-        request = snap.requestBuild(archive=ubuntu.main_archive, distro_arch_series=arm64, pocket='Updates', channels={"snapcraft":"edge"})
-        print(request)
+        if bool ("${{inputs.build1}}"):
+          amd64 = release.getDistroArchSeries(archtag="${{inputs.build1}}")
+          request = snap.requestBuild(archive=ubuntu.main_archive, distro_arch_series=amd64, pocket='Updates', channels={"snapcraft":"edge"})
+          print(request)
+        if bool ("${{inputs.build2}}"):
+          arm64 = release.getDistroArchSeries(archtag="${{inputs.build2}}")
+          request = snap.requestBuild(archive=ubuntu.main_archive, distro_arch_series=arm64, pocket='Updates', channels={"snapcraft":"edge"})
+          print(request)
       shell: python


### PR DESCRIPTION
Add support for build targets
    
Add the ability to specify one or two build targets to build on launchpad
(amd64/arm64)
    
Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>
