### PR TITLE
Add launchpad credentials generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The three secrets used to connect to Launchpad, `consumer_name`, `access_token` 
 The edgex-sync repository has a [list of defined secrets](https://github.com/canonical/edgex-sync/settings/secrets/actions) which include these three.
 
 To regenerate the secrets, if needed, do the following:
-- copy this [Python script](https://github.com/canonical/edgex-sync/blob/main/utils/create-lp-credentals.py) to your computer.
+- copy [create-lp-credentals](create-lp-credentals.py) Python script to your computer.
 - run the script locally
 - It will prompt you to log into launchpad
 - A `.credentials` file will be generated with the secrets. Use the contents of that file to create the Github secrets

--- a/create-lp-credentals.py
+++ b/create-lp-credentals.py
@@ -1,0 +1,26 @@
+# pip3 install launchpadlib
+# https://help.launchpad.net/API/launchpadlib
+# https://help.launchpad.net/API/SigningRequests
+
+import os
+import sys
+import argparse
+
+from launchpadlib.launchpad import Launchpad
+from launchpadlib.launchpad import Credentials
+
+home = os.getenv("HOME")
+workdir = home+"/snap-builds"
+cachedir = workdir+"/tmp"
+creds = "./credentials"
+
+launchpad = Launchpad.login_with('EdgeX Snap Build Trigger',
+                                 'production', cachedir,
+                                 credentials_file=creds,
+                                version='devel')
+
+print ("The secrets are in the ./credentials file")
+print("Copy them to the Github Secrets LP_CONSUMER_NAME, LP_ACCESS_TOKEN and LP_ACCESS_SECRET")
+edgex_team = launchpad.people["canonical-edgex"]
+print(edgex_team.display_name)
+


### PR DESCRIPTION
Moved from https://github.com/canonical/edgex-sync/blob/43d3c04ea127630daa7ad7fb7faa6487ab1aa0a4/utils/create-lp-credentals.py